### PR TITLE
for test

### DIFF
--- a/internal/server/adapters/api/rest/rest.go
+++ b/internal/server/adapters/api/rest/rest.go
@@ -27,7 +27,7 @@ const (
 	metricName  = "metricName"
 
 	contentType   = "Content-Type"
-	serverTimeout = 3
+	serverTimeout = 30
 )
 
 type MetricService interface {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve error handling and transaction management in the SetMetrics function by ensuring rollback on errors and switching to transaction-based database operations. Increase server timeout from 3 to 30 seconds.

Bug Fixes:
- Ensure transaction rollback is attempted in case of errors during metric insertion in the SetMetrics function.

Enhancements:
- Change the database operations in SetMetrics to use a transaction instead of direct database access.

<!-- Generated by sourcery-ai[bot]: end summary -->